### PR TITLE
fix panic when file/dir is deleted

### DIFF
--- a/watcher.go
+++ b/watcher.go
@@ -497,9 +497,12 @@ func (w *Watcher) retrieveFileList() map[string]os.FileInfo {
 			if err != nil {
 				if os.IsNotExist(err) {
 					w.mu.Unlock()
-					if name == err.(*os.PathError).Path {
-						w.Error <- ErrWatchedFileDeleted
-						w.RemoveRecursive(name)
+					pathErr, ok := err.(*os.PathError)
+					if ok {
+						if name == pathErr.Path {
+							w.Error <- ErrWatchedFileDeleted
+							w.RemoveRecursive(name)
+						}
 					}
 					w.mu.Lock()
 				} else {
@@ -511,9 +514,12 @@ func (w *Watcher) retrieveFileList() map[string]os.FileInfo {
 			if err != nil {
 				if os.IsNotExist(err) {
 					w.mu.Unlock()
-					if name == err.(*os.PathError).Path {
-						w.Error <- ErrWatchedFileDeleted
-						w.Remove(name)
+					pathErr, ok := err.(*os.PathError)
+					if ok {
+						if name == pathErr.Path {
+							w.Error <- ErrWatchedFileDeleted
+							w.Remove(name)
+						}
 					}
 					w.mu.Lock()
 				} else {


### PR DESCRIPTION
sometimes when a file/dir which is being watched is
deleted a panic will occur. This appears to be because
the is an assumption that if an error returns true for
`IsNotExist()` that it should be castable to `os.PathError`,
but this evidently is not always the case, causing a panic.